### PR TITLE
Fixed self.res_ar empty checks to use .size

### DIFF
--- a/pyBumpHunter/bumphunter_1dim.py
+++ b/pyBumpHunter/bumphunter_1dim.py
@@ -1508,7 +1508,7 @@ class BumpHunter1D:
         """
 
         # Check if there is anything to show.
-        if self.res_ar == []:
+        if self.res_ar.size == 0:
             print("Nothing to plot here !")
             return
 
@@ -1980,7 +1980,7 @@ class BumpHunter1D:
         """
 
         # Check if we are in multi_chan
-        if self.res_ar != [] and self.res_ar.ndim == 2:
+        if self.res_ar.size > 0 and self.res_ar.ndim == 2:
             multi_chan = True
         else:
             multi_chan = False


### PR DESCRIPTION
`self.res_ar` is typically used as a NumPy array, and comparing a NumPy array to an empty list with `==` is not safe. One safe way to check if a NumPy array is empty is with `self.res_ar.size == 0`.