### PR TITLE
Update pre-commit hooks and require Python 3.8+

### DIFF
--- a/.github/workflows/automated_testing.yml
+++ b/.github/workflows/automated_testing.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7,3.8,3.9,'3.10']
+        python-version: [3.8,3.9,'3.10']
 
     steps:
     - uses: actions/checkout@v1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 22.3.0
+    rev: 25.1.0
     hooks:
       - id: black
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v6.0.0
     hooks:
       - id: check-added-large-files
       - id: check-case-conflict
@@ -19,24 +19,24 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/mgedmin/check-manifest
-    rev: "0.48"
+    rev: "0.50"
     hooks:
       - id: check-manifest
         stages: [ manual ]
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.31.1
+    rev: v3.20.0
     hooks:
       - id: pyupgrade
         args: [ --py36-plus ]
 
   - repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v1.20.0
+    rev: v2.8.0
     hooks:
       - id: setup-cfg-fmt
 
   - repo: https://github.com/pycqa/flake8
-    rev: 4.0.1
+    rev: 7.3.0
     hooks:
       - id: flake8
         additional_dependencies:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The BumpHunter algorithm can also perform signal injection tests where more and 
 
 ### Dependencies
 
-Requires python >= 3.6 py
+Requires Python >= 3.8.
 
 BumpHunter depends on the following python libraries :
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,8 +14,6 @@ classifiers =
     License :: OSI Approved :: BSD License
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -31,7 +29,7 @@ install_requires =
     matplotlib
     numpy>=1.13.3
     scipy
-python_requires = >=3.6
+python_requires = >=3.8
 
 [options.packages.find]
 exclude = test


### PR DESCRIPTION
Here is some basic modernisation for things to run OK again.

I would suggest to start the modernisation with this trivial update and then make more serious updates based on the repo review https://learn.scientific-python.org/development/guides/repo-review/ from @henryiii.