### PR TITLE
chore: setup pre-commit and format codebase (Phase 1)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,43 +1,23 @@
-repos:
-  - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 25.1.0
-    hooks:
-      - id: black
+ci:
+  autoupdate_commit_msg: "chore: update pre-commit hooks"
+  autofix_commit_msg: "style: pre-commit fixes"
+  autoupdate_schedule: monthly
 
+repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:
       - id: check-added-large-files
       - id: check-case-conflict
       - id: check-merge-conflict
-      - id: check-symlinks
       - id: check-yaml
-      - id: debug-statements
       - id: end-of-file-fixer
       - id: mixed-line-ending
-      - id: requirements-txt-fixer
       - id: trailing-whitespace
 
-  - repo: https://github.com/mgedmin/check-manifest
-    rev: "0.50"
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.12
     hooks:
-      - id: check-manifest
-        stages: [ manual ]
-
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.20.0
-    hooks:
-      - id: pyupgrade
-        args: [ --py36-plus ]
-
-  - repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v2.8.0
-    hooks:
-      - id: setup-cfg-fmt
-
-  - repo: https://github.com/pycqa/flake8
-    rev: 7.3.0
-    hooks:
-      - id: flake8
-        additional_dependencies:
-          - flake8-bugbear
+      - id: ruff-check
+        args: ["--fix", "--show-fixes"]
+      - id: ruff-format

--- a/example/example.ipynb
+++ b/example/example.ipynb
@@ -17,7 +17,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "import pyBumpHunter as BH\n",
     "from datetime import datetime  ## Used to compute the execution time\n",
@@ -40,23 +39,23 @@
    "outputs": [],
    "source": [
     "# Open the file\n",
-    "File = upr.open('../data/data.root')\n",
+    "File = upr.open(\"../data/data.root\")\n",
     "File.items()\n",
     "\n",
     "# Background\n",
-    "bkg = File['bkg'].arrays(library='np')['bkg']\n",
+    "bkg = File[\"bkg\"].arrays(library=\"np\")[\"bkg\"]\n",
     "\n",
     "# Data\n",
-    "data = File['data'].arrays(library='np')['data']\n",
+    "data = File[\"data\"].arrays(library=\"np\")[\"data\"]\n",
     "\n",
     "# Signal\n",
-    "sig = File['sig'].arrays(library='np')['sig']\n",
+    "sig = File[\"sig\"].arrays(library=\"np\")[\"sig\"]\n",
     "\n",
     "# Position of the bump in the data\n",
     "Lth = 5.5\n",
     "\n",
     "# Range for the histogram\n",
-    "rang = [0,20]"
+    "rang = [0, 20]"
    ]
   },
   {
@@ -99,7 +98,7 @@
    ],
    "source": [
     "# Plot the 2 distributions (data and background)\n",
-    "F = plt.figure(figsize=(12,8))\n",
+    "F = plt.figure(figsize=(12, 8))\n",
     "plt.title(\"Test distribution\")\n",
     "plt.hist(\n",
     "    (bkg, data),\n",
@@ -109,9 +108,9 @@
     "    label=(\"bakground\", \"data\"),\n",
     "    linewidth=2,\n",
     ")\n",
-    "plt.legend(fontsize='xx-large')\n",
-    "plt.xticks(fontsize='xx-large')\n",
-    "plt.yticks(fontsize='xx-large')\n",
+    "plt.legend(fontsize=\"xx-large\")\n",
+    "plt.xticks(fontsize=\"xx-large\")\n",
+    "plt.yticks(fontsize=\"xx-large\")\n",
     "plt.show()"
    ]
   },
@@ -179,12 +178,12 @@
     }
    ],
    "source": [
-    "print('####bump_scan call####')\n",
+    "print(\"####bump_scan call####\")\n",
     "begin = datetime.now()\n",
     "hunter.bump_scan(data, bkg)\n",
     "end = datetime.now()\n",
-    "print(f'time={end - begin}')\n",
-    "print('')"
+    "print(f\"time={end - begin}\")\n",
+    "print(\"\")"
    ]
   },
   {
@@ -218,7 +217,7 @@
    ],
    "source": [
     "print(hunter.bump_info(data))\n",
-    "print(f'   mean (true) = {Lth}')"
+    "print(f\"   mean (true) = {Lth}\")"
    ]
   },
   {
@@ -280,7 +279,7 @@
     }
    ],
    "source": [
-    "hunter.plot_bump(data,bkg)"
+    "hunter.plot_bump(data, bkg)"
    ]
   },
   {
@@ -418,17 +417,17 @@
     "# We have to set additionnal parameters specific to the signal injection.\n",
     "# All the parameters defined previously are kept.\n",
     "hunter.sigma_limit = 5\n",
-    "hunter.str_min = -1 # if str_scale='log', the real starting value is 10**str_min\n",
-    "hunter.str_scale = 'log'\n",
-    "hunter.signal_exp = 150 # Correspond the the real number of signal events generated when making the data\n",
+    "hunter.str_min = -1  # if str_scale='log', the real starting value is 10**str_min\n",
+    "hunter.str_scale = \"log\"\n",
+    "hunter.signal_exp = 150  # Correspond the the real number of signal events generated when making the data\n",
     "hunter.npe_inject = 2000\n",
     "\n",
-    "print('####singal_inject call####')\n",
+    "print(\"####singal_inject call####\")\n",
     "begin = datetime.now()\n",
-    "hunter.signal_inject(sig,bkg,is_hist=False)\n",
+    "hunter.signal_inject(sig, bkg, is_hist=False)\n",
     "end = datetime.now()\n",
-    "print(f'time={end - begin}')\n",
-    "print('')"
+    "print(f\"time={end - begin}\")\n",
+    "print(\"\")"
    ]
   },
   {
@@ -487,19 +486,19 @@
     }
    ],
    "source": [
-    "F = plt.figure(figsize=(12,8))\n",
+    "F = plt.figure(figsize=(12, 8))\n",
     "plt.hist(\n",
-    "    [hunter.t_ar[:hunter.npe],hunter.t_ar[hunter.npe:]],\n",
+    "    [hunter.t_ar[: hunter.npe], hunter.t_ar[hunter.npe :]],\n",
     "    bins=50,\n",
-    "    histtype='step',\n",
+    "    histtype=\"step\",\n",
     "    lw=2,\n",
-    "    label=['bkg only', 'bkg+sig']\n",
+    "    label=[\"bkg only\", \"bkg+sig\"],\n",
     ")\n",
-    "plt.legend(fontsize='x-large')\n",
-    "plt.xlabel('BH stat', size='x-large')\n",
-    "plt.xticks(fontsize='x-large')\n",
-    "plt.yticks(fontsize='x-large')\n",
-    "plt.yscale('log')\n",
+    "plt.legend(fontsize=\"x-large\")\n",
+    "plt.xlabel(\"BH stat\", size=\"x-large\")\n",
+    "plt.xticks(fontsize=\"x-large\")\n",
+    "plt.yticks(fontsize=\"x-large\")\n",
+    "plt.yscale(\"log\")\n",
     "plt.show()"
    ]
   },

--- a/example/example.py
+++ b/example/example.py
@@ -40,9 +40,9 @@ plt.hist(
     label=("bakground", "data"),
     linewidth=2,
 )
-plt.legend(fontsize='xx-large')
-plt.xticks(fontsize='xx-large')
-plt.yticks(fontsize='xx-large')
+plt.legend(fontsize="xx-large")
+plt.xticks(fontsize="xx-large")
+plt.yticks(fontsize="xx-large")
 plt.savefig("results/1D/hist.png", bbox_inches="tight")
 plt.close(F)
 
@@ -100,4 +100,3 @@ print("")
 hunter.plot_inject(
     filename=("results/1D/SignalInject.png", "results/1D/SignalInject_log.png")
 )
-

--- a/example/example2D.ipynb
+++ b/example/example2D.ipynb
@@ -41,7 +41,9 @@
    "source": [
     "# Generate the background\n",
     "np.random.seed(42)\n",
-    "bkg = np.random.exponential(scale=[4, 4], size=(1_000_000, 2)) # Need more stat to have a smoother reference\n",
+    "bkg = np.random.exponential(\n",
+    "    scale=[4, 4], size=(1_000_000, 2)\n",
+    ")  # Need more stat to have a smoother reference\n",
     "\n",
     "# Generate the data\n",
     "Nsig = 700\n",
@@ -144,7 +146,7 @@
     "    npe=8000,\n",
     "    nworker=1,\n",
     "    seed=666,\n",
-    "    use_sideband=True # Activate side-band normalization\n",
+    "    use_sideband=True,  # Activate side-band normalization\n",
     ")"
    ]
   },
@@ -219,8 +221,8 @@
     }
    ],
    "source": [
-    "#hunter.print_bump_info()\n",
-    "#hunter.print_bump_true(data, bkg)\n",
+    "# hunter.print_bump_info()\n",
+    "# hunter.print_bump_true(data, bkg)\n",
     "print(hunter.bump_info(data))\n",
     "print(f\"   mean (true) = {Lth}\")"
    ]

--- a/example/example2D.py
+++ b/example/example2D.py
@@ -14,7 +14,9 @@ import pyBumpHunter as BH
 
 # Generate the background
 np.random.seed(42)
-bkg = np.random.exponential(scale=[4, 4], size=(1_000_000, 2)) # Need more stat to have a smoother reference
+bkg = np.random.exponential(
+    scale=[4, 4], size=(1_000_000, 2)
+)  # Need more stat to have a smoother reference
 
 # Generate the data
 Nsig = 700
@@ -65,7 +67,7 @@ hunter = BH.BumpHunter2D(
     npe=8000,
     nworker=1,
     seed=666,
-    use_sideband=True # Activate side-band normalization
+    use_sideband=True,  # Activate side-band normalization
 )
 
 # Call the bump_scan method
@@ -87,4 +89,3 @@ hunter.plot_bump(data, bkg, filename="results/2D/bump.png")
 
 # Get and save statistics plot
 hunter.plot_stat(show_Pval=True, filename="results/2D/BH_statistics.png")
-

--- a/pyBumpHunter/bumphunter_1dim.py
+++ b/pyBumpHunter/bumphunter_1dim.py
@@ -262,7 +262,7 @@ class BumpHunter1D:
 
             seed :
                 Seed for the random number generator.
-                Default to None. 
+                Default to None.
 
             use_sideband :
                 Boolean specifying if the side-band normalization should be applied.
@@ -428,9 +428,9 @@ class BumpHunter1D:
                 )
 
             if self.use_sideband:
-                res[i][
-                    res[i] < 1e-300
-                ] = 1e-300  # prevent issue with very low p-value, sometimes induced by normalisation in the tail
+                res[i][res[i] < 1e-300] = (
+                    1e-300  # prevent issue with very low p-value, sometimes induced by normalisation in the tail
+                )
 
             # Get the minimum p-value and associated position for width w
             min_Pval[i] = res[i].min()
@@ -506,7 +506,7 @@ class BumpHunter1D:
         Hinf = []
         Hsup = []
         for ch in range(len(hist)):
-            non0 = [iii for iii in range(0,ref[ch].size) if ref[ch][iii] > 0]
+            non0 = [iii for iii in range(0, ref[ch].size) if ref[ch][iii] > 0]
             Hinf.append(min(non0))
             Hsup.append(max(non0) + 1)
         Hinf = np.array(Hinf)
@@ -530,8 +530,8 @@ class BumpHunter1D:
             ref_total = []
             hist_total = []
             for ch in range(len(hist)):
-                ref_total.append(ref[ch][Vinf[ch]:Vsup[ch]].sum())
-                hist_total.append(hist[ch][Vinf[ch]:Vsup[ch]].sum())
+                ref_total.append(ref[ch][Vinf[ch] : Vsup[ch]].sum())
+                hist_total.append(hist[ch][Vinf[ch] : Vsup[ch]].sum())
             min_scale_all = np.empty(len(hist))
 
         # Compute scan_stepp for all width
@@ -545,10 +545,12 @@ class BumpHunter1D:
         # Compute pos for all width
         pos = []
         for ch in range(len(hist)):
-            pos.append([
-                np.arange(Hinf[ch], Hsup[ch] - w + 1, scan_stepp[i])
-                for i, w in enumerate(w_ar)
-            ])
+            pos.append(
+                [
+                    np.arange(Hinf[ch], Hsup[ch] - w + 1, scan_stepp[i])
+                    for i, w in enumerate(w_ar)
+                ]
+            )
 
         # Initialize p-value container for all channels, width and pos
         res_all = np.empty((len(hist), w_ar.size), dtype=object)
@@ -573,12 +575,9 @@ class BumpHunter1D:
 
                 # Count events in all intervals for channel ch and width w
                 Nref = np.array(
-                    [ref[ch][p : p + w].sum() for p in pos[ch][i]],
-                    dtype=float
+                    [ref[ch][p : p + w].sum() for p in pos[ch][i]], dtype=float
                 )
-                Nhist = np.array(
-                    [hist[ch][p : p + w].sum() for p in pos[ch][i]]
-                )
+                Nhist = np.array([hist[ch][p : p + w].sum() for p in pos[ch][i]])
 
                 # Compute and apply side-band normalization scale factor (if needed)
                 if self.use_sideband:
@@ -629,11 +628,14 @@ class BumpHunter1D:
             else:
                 # Get the right limit of the bump
                 loc_right = min_loc_current + min_width_current
-                loc_right_prev = min_loc_all[ch-1] + min_width_all[ch-1]
+                loc_right_prev = min_loc_all[ch - 1] + min_width_all[ch - 1]
 
                 # Check for overlap
-                if self.bins[ch][loc_right] <= self.bins[ch-1][min_loc_all[ch-1]] \
-                or self.bins[ch][min_loc_current] >= self.bins[ch-1][loc_right_prev]:
+                if (
+                    self.bins[ch][loc_right] <= self.bins[ch - 1][min_loc_all[ch - 1]]
+                    or self.bins[ch][min_loc_current]
+                    >= self.bins[ch - 1][loc_right_prev]
+                ):
                     # No overlap, we can break the loop
                     min_Pval_all = np.full(len(ref), 1)
                     min_loc_all = Hinf
@@ -647,30 +649,44 @@ class BumpHunter1D:
                     min_Pval_all[ch] = min_Pval_current
 
                     # Compute overlap interval (check left bound)
-                    if self.bins[ch][min_loc_current] < self.bins[ch-1][min_loc_all[ch-1]]:
-                        while self.bins[ch][min_loc_current] < self.bins[ch-1][min_loc_all[ch-1]]:
+                    if (
+                        self.bins[ch][min_loc_current]
+                        < self.bins[ch - 1][min_loc_all[ch - 1]]
+                    ):
+                        while (
+                            self.bins[ch][min_loc_current]
+                            < self.bins[ch - 1][min_loc_all[ch - 1]]
+                        ):
                             min_loc_current += 1
                         min_loc_current -= min_loc_current - 1
                     # Check right bound
-                    if self.bins[ch][loc_right] > self.bins[ch-1][loc_right_prev]:
-                        while self.bins[ch][loc_right] > self.bins[ch-1][loc_right_prev]:
+                    if self.bins[ch][loc_right] > self.bins[ch - 1][loc_right_prev]:
+                        while (
+                            self.bins[ch][loc_right] > self.bins[ch - 1][loc_right_prev]
+                        ):
                             loc_right -= 1
-                        loc_right +=1
+                        loc_right += 1
                     # Width
                     min_loc_all[ch] = min_loc_current
                     min_width_all[ch] = loc_right - min_loc_all[ch]
-                    
+
                     # Side-band normalization scale
                     if self.use_sideband:
                         min_scale_all[ch] = min_scale_current
 
         # Use best inverval position and width to compute signal_eval_all
         if ih == 0 and min_Pval_all[-1] < 1:
-            signal_eval_all = np.array([
-                hist[ch][min_loc_all[ch] : min_loc_all[ch] + min_width_all[ch]].sum() \
-                - ref[ch][min_loc_all[ch] : min_loc_all[ch]  + min_width_all[ch]].sum()
-                for ch in range(len(hist))
-            ])
+            signal_eval_all = np.array(
+                [
+                    hist[ch][
+                        min_loc_all[ch] : min_loc_all[ch] + min_width_all[ch]
+                    ].sum()
+                    - ref[ch][
+                        min_loc_all[ch] : min_loc_all[ch] + min_width_all[ch]
+                    ].sum()
+                    for ch in range(len(hist))
+                ]
+            )
 
         # Save the results in inner variables and return
         if ih == 0:
@@ -682,7 +698,6 @@ class BumpHunter1D:
         self.t_ar[ih] = -np.log(min_Pval_all.prod())
         if self.use_sideband and ih == 0:
             self.norm_scale = min_scale_all
-
 
     ## Variable management methods
 
@@ -911,7 +926,7 @@ class BumpHunter1D:
         bkg,
         is_hist: bool = False,
         do_pseudo: bool = True,
-        multi_chan: bool = False
+        multi_chan: bool = False,
     ):
         """
         Function that perform the full BumpHunter algorithm presented in https://arxiv.org/pdf/1101.0390.pdf without sidebands.
@@ -984,23 +999,25 @@ class BumpHunter1D:
             bins = []
             for ch in range(len(data)):
                 if not is_hist:
-                    bkg_hist.append(np.histogram(
-                        bkg[ch],
-                        bins=self.bins[ch],
-                        weights=self.weights,
-                        range=self.rang
-                    )[0])
-                    bins.append(np.histogram_bin_edges(
-                        bkg[ch],
-                        bins=self.bins[ch],
-                        weights=self.weights,
-                        range=self.rang
-                    ))
+                    bkg_hist.append(
+                        np.histogram(
+                            bkg[ch],
+                            bins=self.bins[ch],
+                            weights=self.weights,
+                            range=self.rang,
+                        )[0]
+                    )
+                    bins.append(
+                        np.histogram_bin_edges(
+                            bkg[ch],
+                            bins=self.bins[ch],
+                            weights=self.weights,
+                            range=self.rang,
+                        )
+                    )
                     data_hist.append(
-                        np.histogram(data[ch],
-                        bins=bins[ch],
-                        range=self.rang
-                    )[0])
+                        np.histogram(data[ch], bins=bins[ch], range=self.rang)[0]
+                    )
                 else:
                     if self.weights is None:
                         bkg_hist.append(bkg[ch])
@@ -1009,7 +1026,9 @@ class BumpHunter1D:
                     data_hist.append(data[ch])
         else:
             if not is_hist:
-                bkg_hist, bins = np.histogram(bkg, bins=self.bins, weights=self.weights, range=self.rang)
+                bkg_hist, bins = np.histogram(
+                    bkg, bins=self.bins, weights=self.weights, range=self.rang
+                )
                 data_hist = np.histogram(data, bins=bins, range=self.rang)[0]
             else:
                 if self.weights is None:
@@ -1031,14 +1050,13 @@ class BumpHunter1D:
                 pseudo_hist = []
                 for ch in range(len(data)):
                     pseudo_hist.append(
-                            np.random.poisson(
+                        np.random.poisson(
                             lam=np.tile(bkg_hist[ch], (self.npe, 1)).transpose(),
                             size=(bkg_hist[ch].size, self.npe),
                         )
                     )
                 # Convert the list into a 3D numpy array
-                #pseudo_hist = np.array(pseudo_hist)
-                
+                # pseudo_hist = np.array(pseudo_hist)
 
             else:
                 pseudo_hist = np.random.poisson(
@@ -1102,7 +1120,7 @@ class BumpHunter1D:
                                 )
                             else:
                                 pseudo = [
-                                    pseudo_hist[ch][:, th-1]
+                                    pseudo_hist[ch][:, th - 1]
                                     for ch in range(len(data))
                                 ]
                                 exe.submit(
@@ -1133,38 +1151,17 @@ class BumpHunter1D:
                 for i in range(self.npe + 1):
                     if multi_chan:
                         if i == 0:
-                            self._scan_hist_multi(
-                                data_hist,
-                                bkg_hist,
-                                w_ar,
-                                i
-                            )
+                            self._scan_hist_multi(data_hist, bkg_hist, w_ar, i)
                         else:
                             pseudo = [
-                                pseudo_hist[ch][:, i-1]
-                                for ch in range(len(data))
+                                pseudo_hist[ch][:, i - 1] for ch in range(len(data))
                             ]
-                            self._scan_hist_multi(
-                                pseudo,
-                                bkg_hist,
-                                w_ar,
-                                i
-                            )
+                            self._scan_hist_multi(pseudo, bkg_hist, w_ar, i)
                     else:
                         if i == 0:
-                            self._scan_hist(
-                                data_hist,
-                                bkg_hist,
-                                w_ar,
-                                i
-                            )
+                            self._scan_hist(data_hist, bkg_hist, w_ar, i)
                         else:
-                            self._scan_hist(
-                                pseudo_hist[:, i - 1],
-                                bkg_hist,
-                                w_ar,
-                                i
-                            )
+                            self._scan_hist(pseudo_hist[:, i - 1], bkg_hist, w_ar, i)
         else:
             if multi_chan:
                 self._scan_hist_multi(data_hist, bkg_hist, w_ar, 0)
@@ -1274,7 +1271,8 @@ class BumpHunter1D:
         print("Generating background only histograms")
         np.random.seed(self.seed)
         pseudo_bkg = np.random.poisson(
-            lam=np.tile(bkg_hist, (self.npe, 1)).transpose(), size=(bkg_hist.size, self.npe)
+            lam=np.tile(bkg_hist, (self.npe, 1)).transpose(),
+            size=(bkg_hist.size, self.npe),
         )
 
         # Set width_max if it is given as None
@@ -1317,8 +1315,9 @@ class BumpHunter1D:
 
         # Main injection loop
         print("STARTING INJECTION")
-        while (self.significance < self.sigma_limit)\
-        and (self.global_Pval > 1 / self.npe):
+        while (self.significance < self.sigma_limit) and (
+            self.global_Pval > 1 / self.npe
+        ):
             # Check how we should compute the signal strength to be injected
             if self.str_scale == "lin":
                 # Signal strength increase linearly at each step
@@ -1416,17 +1415,17 @@ class BumpHunter1D:
             )
 
             # If global p-value is exactly 0, we might have trouble with the significance
-            if self.global_Pval <  1 / self.npe:
+            if self.global_Pval < 1 / self.npe:
                 self.significance = norm.ppf(1 - (1 / self.npe))
             else:
                 self.significance = norm.ppf(1 - self.global_Pval)
 
-            if global_inf <  1 / self.npe:
+            if global_inf < 1 / self.npe:
                 sigma_inf = norm.ppf(1 - (1 / self.npe))
             else:
                 sigma_inf = norm.ppf(1 - global_inf)
 
-            if global_sup <  1 / self.npe:
+            if global_sup < 1 / self.npe:
                 sigma_sup = norm.ppf(1 - (1 / self.npe))
             else:
                 sigma_sup = norm.ppf(1 - global_sup)
@@ -1478,7 +1477,9 @@ class BumpHunter1D:
     ## Display methods
 
     # Method that do the tomography plot for the data
-    def plot_tomography(self, bkg, is_hist: bool = False, label: str = '' , filename=None, chan: int = 0):
+    def plot_tomography(
+        self, bkg, is_hist: bool = False, label: str = "", filename=None, chan: int = 0
+    ):
         """
         Function that do a tomography plot showing the local p-value for every positions and widths of the scan
         window.
@@ -1524,17 +1525,19 @@ class BumpHunter1D:
             H = []
             if not is_hist:
                 for ch in range(len(bkg)):
-                    Hbkg.append(np.histogram(
-                        bkg[ch],
-                        bins=self.bins[ch],
-                        range=self.rang,
-                        weights=self.weights
-                    )[0])
-                    H.append(np.histogram_bin_edges(
-                        bkg[ch],
-                        bins=self.bins[ch],
-                        range=self.rang
-                    ))
+                    Hbkg.append(
+                        np.histogram(
+                            bkg[ch],
+                            bins=self.bins[ch],
+                            range=self.rang,
+                            weights=self.weights,
+                        )[0]
+                    )
+                    H.append(
+                        np.histogram_bin_edges(
+                            bkg[ch], bins=self.bins[ch], range=self.rang
+                        )
+                    )
             else:
                 H = self.bins
                 if self.weights is None:
@@ -1556,7 +1559,7 @@ class BumpHunter1D:
         # Remove empty bins at the begining of reference
         Hinf = 0
         if multi_chan:
-            non0 = [i for i in range(0,Hbkg[chan].size) if Hbkg[chan][i] > 0]
+            non0 = [i for i in range(0, Hbkg[chan].size) if Hbkg[chan][i] > 0]
             Hinf = min(non0)
         else:
             non0 = [i for i in range(Hbkg.size) if Hbkg[i] > 0]
@@ -1564,7 +1567,7 @@ class BumpHunter1D:
 
         # Select the required channel (if needed)
         if multi_chan:
-            res_data = self.res_ar[chan,:]
+            res_data = self.res_ar[chan, :]
             H = H[chan]
         else:
             res_data = self.res_ar
@@ -1617,10 +1620,10 @@ class BumpHunter1D:
         bkg,
         is_hist: bool = False,
         use_sideband=None,
-        label: str = '',
+        label: str = "",
         filename=None,
         chan: int = 0,
-        useSideBand=None
+        useSideBand=None,
     ):
         """
         Plot the data and bakground histograms with the bump found by BumpHunter highlighted.
@@ -1674,7 +1677,7 @@ class BumpHunter1D:
             if not is_hist:
                 # Take the histogram bin content for the required channel
                 H = np.histogram(data[chan], bins=self.bins[chan], range=self.rang)
-                    
+
                 H = [H[0], H[1]]
             else:
                 H = np.histogram(data[chan], bins=self.bins, range=self.rang)
@@ -1686,14 +1689,13 @@ class BumpHunter1D:
 
         # Get bump min and max
         if multi_chan:
-            Bmin = np.array([
-                H[1][self.min_loc_ar[0][ch]]
-                for ch in range(len(data))
-            ])
-            Bmax = np.array([
-                H[1][self.min_loc_ar[0][ch] + self.min_width_ar[0][ch]]
-                for ch in range(len(data))
-            ])
+            Bmin = np.array([H[1][self.min_loc_ar[0][ch]] for ch in range(len(data))])
+            Bmax = np.array(
+                [
+                    H[1][self.min_loc_ar[0][ch] + self.min_width_ar[0][ch]]
+                    for ch in range(len(data))
+                ]
+            )
             Bmin = Bmin.max()
             Bmax = Bmax.min()
         else:
@@ -1707,7 +1709,7 @@ class BumpHunter1D:
                     bkg[chan],
                     bins=self.bins[chan],
                     range=self.rang,
-                    weights=self.weights
+                    weights=self.weights,
                 )[0]
             else:
                 if self.weights is None:
@@ -1775,12 +1777,7 @@ class BumpHunter1D:
         )
 
         plt.vlines(
-            [Bmin, Bmax],
-            0,
-            H[0].max(),
-            colors="r",
-            linestyles='dashed',
-            label="BUMP"
+            [Bmin, Bmax], 0, H[0].max(), colors="r", linestyles="dashed", label="BUMP"
         )
         plt.legend(fontsize="xx-large")
         plt.yscale("log")
@@ -1835,7 +1832,7 @@ class BumpHunter1D:
         if show_Pval:
             plt.title(
                 f"BumpHunter statistics distribution      global p-value = {self.global_Pval:1.4f}",
-                size="xx-large"
+                size="xx-large",
             )
         else:
             plt.title("BumpHunter statistics distribution")
@@ -1915,9 +1912,9 @@ class BumpHunter1D:
             self.sigma_ar[:, 0],
             xerr=0,
             yerr=[self.sigma_ar[:, 1], self.sigma_ar[:, 2]],
-            marker='o',
+            marker="o",
             linewidth=2,
-            uplims=is_sat
+            uplims=is_sat,
         )
         plt.xlabel("Signal strength", size="xx-large")
         plt.ylabel("Significance", size="xx-large")
@@ -1942,9 +1939,9 @@ class BumpHunter1D:
                 self.sigma_ar[:, 0],
                 xerr=0,
                 yerr=[self.sigma_ar[:, 1], self.sigma_ar[:, 2]],
-                marker='o',
+                marker="o",
                 linewidth=2,
-                uplims=is_sat
+                uplims=is_sat,
             )
             plt.xlabel("Signal strength", size="xx-large")
             plt.ylabel("Significance", size="xx-large")
@@ -1966,7 +1963,7 @@ class BumpHunter1D:
         return self.plot_inject(*args, **kwargs)
 
     # Method to obtained a printable string containing all the results of the last BumpHunter scans
-    def bump_info(self, data, is_hist: bool=False):
+    def bump_info(self, data, is_hist: bool = False):
         """
         Method that return a formated string with all the results of the last performed scan.
 
@@ -1984,7 +1981,6 @@ class BumpHunter1D:
             multi_chan = True
         else:
             multi_chan = False
-        
 
         # Get the bin edges
         if not is_hist:
@@ -1992,11 +1988,11 @@ class BumpHunter1D:
                 # Loop over channel
                 bins = []
                 for ch in range(len(data)):
-                    bins.append(np.histogram_bin_edges(
-                        data[ch],
-                        bins=self.bins[ch],
-                        range=self.rang
-                    ))
+                    bins.append(
+                        np.histogram_bin_edges(
+                            data[ch], bins=self.bins[ch], range=self.rang
+                        )
+                    )
             else:
                 bins = np.histogram_bin_edges(data, bins=self.bins, range=self.rang)
         else:
@@ -2004,14 +2000,15 @@ class BumpHunter1D:
 
         # Compute bump edges
         if multi_chan:
-            Bmin = np.array([
-                bins[ch][self.min_loc_ar[0][ch]]
-                for ch in range(len(data))
-            ])
-            Bmax = np.array([
-                bins[ch][self.min_loc_ar[0][ch] + self.min_width_ar[0][ch]]
-                for ch in range(len(data))
-            ])
+            Bmin = np.array(
+                [bins[ch][self.min_loc_ar[0][ch]] for ch in range(len(data))]
+            )
+            Bmax = np.array(
+                [
+                    bins[ch][self.min_loc_ar[0][ch] + self.min_width_ar[0][ch]]
+                    for ch in range(len(data))
+                ]
+            )
 
             # Must take the common overlap window
             Bminc = Bmin.max()
@@ -2025,49 +2022,49 @@ class BumpHunter1D:
             Bwidth = Bmax - Bmin
 
         # Initialise the string
-        bstr = ''
+        bstr = ""
 
         # Append local results to the string
         if multi_chan:
             # Append the bump edges of every channels
-            bstr += 'Bump edges (per channel):\n'
+            bstr += "Bump edges (per channel):\n"
             for ch in range(len(self.min_Pval_ar[0])):
-                bstr += f'    chan {ch+1} -> [{Bmin[ch]:.3g}, {Bmax[ch]:.3g}]'
-                bstr += f'  (loc={self.min_loc_ar[0][ch]}, width={self.min_width_ar[0][ch]})\n'
+                bstr += f"    chan {ch + 1} -> [{Bmin[ch]:.3g}, {Bmax[ch]:.3g}]"
+                bstr += f"  (loc={self.min_loc_ar[0][ch]}, width={self.min_width_ar[0][ch]})\n"
 
             # Append the combined bump edges, mean and width
-            bstr += f'Combined bump edges : [{Bminc:.3g}, {Bmaxc:.3g}]\n'
-            bstr += f'Combined bump mean | width : {Bmean:.3g} | {Bwidth:.3g}\n'
+            bstr += f"Combined bump edges : [{Bminc:.3g}, {Bmaxc:.3g}]\n"
+            bstr += f"Combined bump mean | width : {Bmean:.3g} | {Bwidth:.3g}\n"
 
             # Append evavuated number of signal event (per channel and total)
-            bstr += 'Evaluated number of signal events (per channel):\n'
+            bstr += "Evaluated number of signal events (per channel):\n"
             for ch in range(len(self.min_Pval_ar[0])):
-                bstr += f'    chan {ch+1} -> {self.signal_eval[ch]:.3g}\n'
-            bstr += f'    Total -> {self.signal_eval.sum():.3g}\n'
+                bstr += f"    chan {ch + 1} -> {self.signal_eval[ch]:.3g}\n"
+            bstr += f"    Total -> {self.signal_eval.sum():.3g}\n"
 
             # Append local information
-            bstr += 'Local p-value (per channel):\n'
+            bstr += "Local p-value (per channel):\n"
             for ch in range(len(self.min_Pval_ar[0])):
-                bstr += f'    chan {ch+1} -> {self.min_Pval_ar[0][ch]:.5g}\n'
-            bstr += f'Local p-value | test statistic (combined) : {self.min_Pval_ar[0].prod():.5g}'
-            bstr += f' | {self.t_ar[0]:.5g}\n'
-            bstr += f'Local significance (combined) : {norm.ppf(1 - self.min_Pval_ar[0].prod()):.5g}\n'
+                bstr += f"    chan {ch + 1} -> {self.min_Pval_ar[0][ch]:.5g}\n"
+            bstr += f"Local p-value | test statistic (combined) : {self.min_Pval_ar[0].prod():.5g}"
+            bstr += f" | {self.t_ar[0]:.5g}\n"
+            bstr += f"Local significance (combined) : {norm.ppf(1 - self.min_Pval_ar[0].prod()):.5g}\n"
         else:
             # Append results for only one channel (no 'combined')
-            bstr += f'Bump edges : [{Bmin:.3g}, {Bmax:.3g}]'
-            bstr += f'  (loc={self.min_loc_ar[0]}, width={self.min_width_ar[0]})\n'
-            bstr += f'Bump mean | width : {Bmean:.3g} | {Bwidth:.3g}\n'
-            bstr += f'Evaluated number of signal events : {self.signal_eval:.3g}\n'
-            bstr += f'Local p-value | test statistic : {self.min_Pval_ar[0]:.5g}'
-            bstr += f' | {self.t_ar[0]:.5g}\n'
-            bstr += f'Local significance : {norm.ppf(1 - self.min_Pval_ar[0]):.5g}\n'
+            bstr += f"Bump edges : [{Bmin:.3g}, {Bmax:.3g}]"
+            bstr += f"  (loc={self.min_loc_ar[0]}, width={self.min_width_ar[0]})\n"
+            bstr += f"Bump mean | width : {Bmean:.3g} | {Bwidth:.3g}\n"
+            bstr += f"Evaluated number of signal events : {self.signal_eval:.3g}\n"
+            bstr += f"Local p-value | test statistic : {self.min_Pval_ar[0]:.5g}"
+            bstr += f" | {self.t_ar[0]:.5g}\n"
+            bstr += f"Local significance : {norm.ppf(1 - self.min_Pval_ar[0]):.5g}\n"
 
         # Append global results to the string
-        bstr += f'Global p-value : {self.global_Pval:.5g}\n'
+        bstr += f"Global p-value : {self.global_Pval:.5g}\n"
         if self.global_Pval == 0:
-            bstr += f'Global significance : >{self.significance:.3g}  (lower limit)'
+            bstr += f"Global significance : >{self.significance:.3g}  (lower limit)"
         else:
-            bstr += f'Global significance : {self.significance:.3g}'
+            bstr += f"Global significance : {self.significance:.3g}"
 
         return bstr
 
@@ -2092,18 +2089,17 @@ class BumpHunter1D:
             print(f"   local significance = {norm.ppf(1 - self.min_Pval_ar[0]):.5f}")
         else:
             # Keep printing stuff for multiple channels
-            print(
-                "   local p-value (per channel) = [",
-                end=''
-            )
+            print("   local p-value (per channel) = [", end="")
             [
-                print(f"{self.min_Pval_ar[0][ch]:.5g}  ",end='')
+                print(f"{self.min_Pval_ar[0][ch]:.5g}  ", end="")
                 for ch in range(len(self.min_Pval_ar[0]))
             ]
             print("]")
             print(f"   local p-value (combined) = {self.min_Pval_ar[0].prod():.5g}")
             print(f"   -ln(loc p-value) (combined) = {self.t_ar[0]:.5f}")
-            print(f"   local significance (combined) = {norm.ppf(1 - self.min_Pval_ar[0].prod()):.5f}")
+            print(
+                f"   local significance (combined) = {norm.ppf(1 - self.min_Pval_ar[0].prod()):.5f}"
+            )
 
         print("")
 
@@ -2146,11 +2142,11 @@ class BumpHunter1D:
                 # Loop over channel
                 bins = []
                 for ch in range(len(data)):
-                    bins.append(np.histogram_bin_edges(
-                        data[ch],
-                        bins=self.bins[ch],
-                        range=self.rang
-                    ))
+                    bins.append(
+                        np.histogram_bin_edges(
+                            data[ch], bins=self.bins[ch], range=self.rang
+                        )
+                    )
             else:
                 bins = np.histogram_bin_edges(data, bins=self.bins, range=self.rang)
         else:
@@ -2158,14 +2154,15 @@ class BumpHunter1D:
 
         # Compute real bump edges
         if multi_chan:
-            Bmin = np.array([
-                bins[ch][self.min_loc_ar[0][ch]]
-                for ch in range(len(data))
-            ])
-            Bmax = np.array([
-                bins[ch][self.min_loc_ar[0][ch] + self.min_width_ar[0][ch]]
-                for ch in range(len(data))
-            ])
+            Bmin = np.array(
+                [bins[ch][self.min_loc_ar[0][ch]] for ch in range(len(data))]
+            )
+            Bmax = np.array(
+                [
+                    bins[ch][self.min_loc_ar[0][ch] + self.min_width_ar[0][ch]]
+                    for ch in range(len(data))
+                ]
+            )
 
             # Must take the common overlap window
             Bmin = Bmin.max()
@@ -2320,5 +2317,3 @@ class BumpHunterInterface(metaclass=ABCMeta):
         during the last iteration (when sigma_limit is reached).
         """
         pass
-
-

--- a/pyBumpHunter/bumphunter_2dim.py
+++ b/pyBumpHunter/bumphunter_2dim.py
@@ -380,8 +380,9 @@ class BumpHunter2D(BumpHunterInterface):
 
         # Create the results array
         res = np.empty(w_ar.shape[0], dtype=object)
-        min_Pval, min_loc = np.empty(w_ar.shape[0]), np.empty(
-            w_ar.shape[0], dtype=object
+        min_Pval, min_loc = (
+            np.empty(w_ar.shape[0]),
+            np.empty(w_ar.shape[0], dtype=object),
         )
         signal_eval = np.empty(w_ar.shape[0])
 
@@ -430,7 +431,7 @@ class BumpHunter2D(BumpHunterInterface):
             # FIXME any better way to do it ?? Without loop ?? FIXME
             Nref = np.array(
                 [ref[p[0] : p[0] + w[0], p[1] : p[1] + w[1]].sum() for p in pos],
-                dtype=float
+                dtype=float,
             )
             Nhist = np.array(
                 [hist[p[0] : p[0] + w[0], p[1] : p[1] + w[1]].sum() for p in pos]
@@ -453,9 +454,9 @@ class BumpHunter2D(BumpHunterInterface):
                 )
 
             if self.use_sideband:
-                res[i][
-                    res[i] < 1e-300
-                ] = 1e-300  # prevent issue with very low p-value, sometimes induced by normalisation in the tail
+                res[i][res[i] < 1e-300] = (
+                    1e-300  # prevent issue with very low p-value, sometimes induced by normalisation in the tail
+                )
 
             # Get the minimum p-value and associated position for width w
             min_Pval[i] = res[i].min()
@@ -531,7 +532,7 @@ class BumpHunter2D(BumpHunterInterface):
             Vinf = np.zeros((len(hist), 2), dtype=int)
             Vsup = np.array(
                 [[hist[ch].shape[0], hist[ch].shape[1]] for ch in range(len(hist))],
-                dtype=int
+                dtype=int,
             )
             if self.sideband_width is not None:
                 Hinf = Vinf + self.sideband_width
@@ -543,7 +544,7 @@ class BumpHunter2D(BumpHunterInterface):
             Hinf = np.zeros((len(hist), 2), dtype=int)
             Hsup = np.array(
                 [[hist[ch].shape[0], hist[ch].shape[1]] for ch in range(len(hist))],
-                dtype=int
+                dtype=int,
             )
 
         # Initialize the global results for all channels
@@ -578,9 +579,7 @@ class BumpHunter2D(BumpHunterInterface):
             scan_steppy = [self.scan_step[1] for w in w_ar]
 
         # Put together scan_steppx and scan_steppy
-        scan_stepp = [
-            [scan_steppx[i], scan_steppy[i]] for i in range(w_ar.shape[0])
-        ]
+        scan_stepp = [[scan_steppx[i], scan_steppy[i]] for i in range(w_ar.shape[0])]
         del scan_steppx
         del scan_steppy
 
@@ -595,13 +594,14 @@ class BumpHunter2D(BumpHunterInterface):
                 np.arange(Hinf[ch, 1], Hinf[ch, 0] - w[1] + 1, scan_stepp[i][1])
                 for i, w in enumerate(w_ar)
             ]
-            pos.append([
-                np.array([
-                    [p[0], p[1]]
-                    for p in itertools.product(posx[i], posy[i])
-                ])
-                for i in range(w_ar.shape[0])
-            ])
+            pos.append(
+                [
+                    np.array(
+                        [[p[0], p[1]] for p in itertools.product(posx[i], posy[i])]
+                    )
+                    for i in range(w_ar.shape[0])
+                ]
+            )
         del posx
         del posy
 
@@ -628,15 +628,21 @@ class BumpHunter2D(BumpHunterInterface):
 
                 # Count events in all intervals for channel ch and width w
                 Nref = np.array(
-                    [ref[ch][p[0] : p[0] + w[0], p[1] : p[1] + w[1]].sum() for p in pos[ch][i]],
-                    dtype=float
+                    [
+                        ref[ch][p[0] : p[0] + w[0], p[1] : p[1] + w[1]].sum()
+                        for p in pos[ch][i]
+                    ],
+                    dtype=float,
                 )
                 Nhist = np.array(
-                    [hist[ch][p[0] : p[0] + w[0], p[1] : p[1] + w[1]].sum() for p in pos[ch][i]]
+                    [
+                        hist[ch][p[0] : p[0] + w[0], p[1] : p[1] + w[1]].sum()
+                        for p in pos[ch][i]
+                    ]
                 )
 
                 # Apply side-band normalization if required
-                if self.use_sideband == True:
+                if self.use_sideband:
                     scale = (hist_total[ch] - Nhist) / (ref_total[ch] - Nref)
                     Nref *= scale
 
@@ -685,16 +691,20 @@ class BumpHunter2D(BumpHunterInterface):
                 # Get the right limit of the bump
                 loc_right = [
                     min_loc_current[0] + min_width_current[0],
-                    min_loc_current[1] + min_width_current[1]
+                    min_loc_current[1] + min_width_current[1],
                 ]
                 loc_right_prev = [
-                    min_loc_all[ch-1][0] + min_width_all[ch-1][0],
-                    min_loc_all[ch-1][1] + min_width_all[ch-1][1]
+                    min_loc_all[ch - 1][0] + min_width_all[ch - 1][0],
+                    min_loc_all[ch - 1][1] + min_width_all[ch - 1][1],
                 ]
 
                 # Check for overlap
-                if self.bins[ch][0][loc_right[0]] <= self.bins[ch-1][0][min_loc_all[ch-1][0]] \
-                or  self.bins[ch][0][min_loc_current[0]] >= self.bins[ch-1][0][loc_right_prev[0]]:
+                if (
+                    self.bins[ch][0][loc_right[0]]
+                    <= self.bins[ch - 1][0][min_loc_all[ch - 1][0]]
+                    or self.bins[ch][0][min_loc_current[0]]
+                    >= self.bins[ch - 1][0][loc_right_prev[0]]
+                ):
                     # No overlap along axis 0, we can break the loop
                     min_Pval_all = np.full(len(ref), 1)
                     min_loc_all = min_loc_all = [[0, 0] for ch in range(len(hist))]
@@ -703,8 +713,12 @@ class BumpHunter2D(BumpHunterInterface):
                     if self.use_sideband:
                         min_scale_all = None
                     break
-                elif self.bins[ch][1][loc_right[1]] <= self.bins[ch-1][1][min_loc_all[ch-1][1]] \
-                or  self.bins[ch][1][min_loc_current[1]] >= self.bins[ch-1][1][loc_right_prev[1]]:
+                elif (
+                    self.bins[ch][1][loc_right[1]]
+                    <= self.bins[ch - 1][1][min_loc_all[ch - 1][1]]
+                    or self.bins[ch][1][min_loc_current[1]]
+                    >= self.bins[ch - 1][1][loc_right_prev[1]]
+                ):
                     # No overlap along axis 1, we can break the loop
                     min_Pval_all = np.full(len(ref), 1)
                     min_loc_all = min_loc_all = [[0, 0] for ch in range(len(hist))]
@@ -718,28 +732,52 @@ class BumpHunter2D(BumpHunterInterface):
                     min_Pval_all[ch] = min_Pval_current
 
                     # Compute overlap interval (check left bound along 2 axes)
-                    if self.bins[ch][0][min_loc_current[0]] < self.bins[ch-1][0][min_loc_all[ch-1][0]]:
-                        while self.bins[ch][0][min_loc_current[0]] < self.bins[ch-1][0][min_loc_all[ch-1][0]]:
+                    if (
+                        self.bins[ch][0][min_loc_current[0]]
+                        < self.bins[ch - 1][0][min_loc_all[ch - 1][0]]
+                    ):
+                        while (
+                            self.bins[ch][0][min_loc_current[0]]
+                            < self.bins[ch - 1][0][min_loc_all[ch - 1][0]]
+                        ):
                             min_loc_current[0] += 1
                         min_loc_current[0] -= min_loc_current[0] - 1
-                    if self.bins[ch][1][min_loc_current[1]] < self.bins[ch-1][1][min_loc_all[ch-1][1]]:
-                        while self.bins[ch][1][min_loc_current[1]] < self.bins[ch-1][1][min_loc_all[ch-1][1]]:
+                    if (
+                        self.bins[ch][1][min_loc_current[1]]
+                        < self.bins[ch - 1][1][min_loc_all[ch - 1][1]]
+                    ):
+                        while (
+                            self.bins[ch][1][min_loc_current[1]]
+                            < self.bins[ch - 1][1][min_loc_all[ch - 1][1]]
+                        ):
                             min_loc_current[1] += 1
                         min_loc_current[1] -= min_loc_current[1] - 1
                     # Check right bound
-                    if self.bins[ch][0][loc_right[0]] > self.bins[ch-1][0][loc_right_prev[0]]:
-                        while self.bins[ch][0][loc_right[0]] > self.bins[ch-1][0][loc_right_prev[0]]:
+                    if (
+                        self.bins[ch][0][loc_right[0]]
+                        > self.bins[ch - 1][0][loc_right_prev[0]]
+                    ):
+                        while (
+                            self.bins[ch][0][loc_right[0]]
+                            > self.bins[ch - 1][0][loc_right_prev[0]]
+                        ):
                             loc_right[0] -= 1
-                        loc_right[0] +=1
-                    if self.bins[ch][1][loc_right[1]] > self.bins[ch-1][1][loc_right_prev[1]]:
-                        while self.bins[ch][1][loc_right[1]] > self.bins[ch-1][1][loc_right_prev[1]]:
+                        loc_right[0] += 1
+                    if (
+                        self.bins[ch][1][loc_right[1]]
+                        > self.bins[ch - 1][1][loc_right_prev[1]]
+                    ):
+                        while (
+                            self.bins[ch][1][loc_right[1]]
+                            > self.bins[ch - 1][1][loc_right_prev[1]]
+                        ):
                             loc_right[1] -= 1
-                        loc_right[1] +=1
+                        loc_right[1] += 1
                     # Width
                     min_loc_all[ch] = min_loc_current
                     min_width_all[ch] = [
                         loc_right[0] - min_loc_all[ch][0],
-                        loc_right[1] - min_loc_all[ch][1]
+                        loc_right[1] - min_loc_all[ch][1],
                     ]
 
                     # Side-band normalization scale
@@ -748,17 +786,19 @@ class BumpHunter2D(BumpHunterInterface):
 
         # Use best inverval position and width to compute signal_eval_all
         if ih == 0 and min_Pval_all[-1] < 1:
-            signal_eval_all = np.array([
-                hist[ch][
-                    min_loc_all[ch][0] : min_loc_all[ch][0] + min_width_all[ch][0],
-                    min_loc_all[ch][1] : min_loc_all[ch][1] + min_width_all[ch][1]
-                ].sum() \
-                - ref[ch][
-                    min_loc_all[ch][0] : min_loc_all[ch][0] + min_width_all[ch][0],
-                    min_loc_all[ch][1] : min_loc_all[ch][1] + min_width_all[ch][1]
-                ].sum()
-                for ch in range(len(hist))
-            ])
+            signal_eval_all = np.array(
+                [
+                    hist[ch][
+                        min_loc_all[ch][0] : min_loc_all[ch][0] + min_width_all[ch][0],
+                        min_loc_all[ch][1] : min_loc_all[ch][1] + min_width_all[ch][1],
+                    ].sum()
+                    - ref[ch][
+                        min_loc_all[ch][0] : min_loc_all[ch][0] + min_width_all[ch][0],
+                        min_loc_all[ch][1] : min_loc_all[ch][1] + min_width_all[ch][1],
+                    ].sum()
+                    for ch in range(len(hist))
+                ]
+            )
 
         # Save the results in inner variables and return
         if ih == 0:
@@ -770,7 +810,6 @@ class BumpHunter2D(BumpHunterInterface):
         self.t_ar[ih] = -np.log(min_Pval_all.prod())
         if self.use_sideband and ih == 0:
             self.norm_scale = min_scale_all
-
 
     ## Variable management methods
 
@@ -995,7 +1034,7 @@ class BumpHunter2D(BumpHunterInterface):
         bkg,
         is_hist: bool = False,
         do_pseudo: bool = True,
-        multi_chan: bool = False
+        multi_chan: bool = False,
     ):
         """
         Function that perform the full BumpHunter algorithm presented in https://arxiv.org/pdf/1101.0390.pdf without sidebands.
@@ -1073,16 +1112,18 @@ class BumpHunter2D(BumpHunterInterface):
                         bkg[ch][:, 1],
                         bins=self.bins,
                         weights=self.weights,
-                        range=self.rang
+                        range=self.rang,
                     )
                     bkg_hist.append(h)
                     bins.append([bx, by])
-                    data_hist.append(np.histogram2d(
-                        data[ch][:, 0],
-                        data[ch][:, 1],
-                        bins=[bx, by],
-                        range=self.rang
-                    )[0])
+                    data_hist.append(
+                        np.histogram2d(
+                            data[ch][:, 0],
+                            data[ch][:, 1],
+                            bins=[bx, by],
+                            range=self.rang,
+                        )[0]
+                    )
                 else:
                     if self.weights is None:
                         bkg_hist.append(bkg[ch])
@@ -1100,10 +1141,7 @@ class BumpHunter2D(BumpHunterInterface):
                 )
                 bins = [bx, by]
                 data_hist = np.histogram2d(
-                    data[:, 0],
-                    data[:, 1],
-                    bins=bins,
-                    range=self.rang
+                    data[:, 0], data[:, 1], bins=bins, range=self.rang
                 )[0]
             else:
                 if self.weights is None:
@@ -1129,7 +1167,8 @@ class BumpHunter2D(BumpHunterInterface):
                         size=(pseudo_hist[ch].size, self.npe),
                     )
                     pseudo_hist[ch] = np.reshape(
-                        pseudo_hist[ch], (bkg_hist[ch].shape[0], bkg_hist[ch].shape[1], self.npe)
+                        pseudo_hist[ch],
+                        (bkg_hist[ch].shape[0], bkg_hist[ch].shape[1], self.npe),
                     )
             else:
                 pseudo_hist = bkg_hist.flatten()
@@ -1144,9 +1183,15 @@ class BumpHunter2D(BumpHunterInterface):
         # Set width_max if it is given as None
         if self.width_max is None:
             if multi_chan:
-                self.width_max = [data_hist[0].shape[0] // 2, data_hist[0].shape[1] // 2]
+                self.width_max = [
+                    data_hist[0].shape[0] // 2,
+                    data_hist[0].shape[1] // 2,
+                ]
             else:
-                self.width_max = [data_hist[0].shape[0] // 2, data_hist[0].shape[1] // 2]
+                self.width_max = [
+                    data_hist[0].shape[0] // 2,
+                    data_hist[0].shape[1] // 2,
+                ]
 
         # Initialize all results containenrs
         if multi_chan:
@@ -1212,11 +1257,7 @@ class BumpHunter2D(BumpHunterInterface):
                         else:
                             if th == 0:
                                 exe.submit(
-                                    self._scan_hist,
-                                    data_hist,
-                                    bkg_hist,
-                                    w_ar,
-                                    th
+                                    self._scan_hist, data_hist, bkg_hist, w_ar, th
                                 )
                             else:
                                 exe.submit(
@@ -1230,41 +1271,20 @@ class BumpHunter2D(BumpHunterInterface):
                 for i in range(self.npe + 1):
                     if multi_chan:
                         if i == 0:
-                            self._scan_hist_multi(
-                                data_hist,
-                                bkg_hist,
-                                w_ar,
-                                i
-                            )
+                            self._scan_hist_multi(data_hist, bkg_hist, w_ar, i)
                         else:
                             pseudo = [
-                                pseudo_hist[ch][:, :, i - 1]
-                                for ch in range(len(data))
+                                pseudo_hist[ch][:, :, i - 1] for ch in range(len(data))
                             ]
-                            self._scan_hist_multi(
-                                pseudo,
-                                bkg_hist,
-                                w_ar,
-                                i
-                            )
+                            self._scan_hist_multi(pseudo, bkg_hist, w_ar, i)
                     else:
                         if i == 0:
-                            self._scan_hist(
-                                data_hist,
-                                bkg_hist,
-                                w_ar,
-                                i
-                            )
+                            self._scan_hist(data_hist, bkg_hist, w_ar, i)
                         else:
-                            self._scan_hist(
-                                pseudo_hist[:, :, i - 1],
-                                bkg_hist,
-                                w_ar,
-                                i
-                            )
+                            self._scan_hist(pseudo_hist[:, :, i - 1], bkg_hist, w_ar, i)
         else:
             if multi_chan:
-                self._scan_hist_multi(data_hist, bkg_hist, w_ar,comb, 0)
+                self._scan_hist_multi(data_hist, bkg_hist, w_ar, 0)
             else:
                 self._scan_hist(data_hist, bkg_hist, w_ar, 0)
 
@@ -1578,10 +1598,10 @@ class BumpHunter2D(BumpHunterInterface):
         bkg,
         is_hist: bool = False,
         use_sideband=None,
-        label: str = '',
+        label: str = "",
         filename=None,
         chan: int = 0,
-        useSideBand=None
+        useSideBand=None,
     ):
         """
         Plot the data and bakground histograms with the bump found by BumpHunter highlighted.
@@ -1638,7 +1658,7 @@ class BumpHunter2D(BumpHunterInterface):
                     data[chan][:, 0],
                     data[chan][:, 1],
                     bins=self.bins[chan],
-                    range=self.rang
+                    range=self.rang,
                 )
                 H = [H[0], [H[1], H[2]]]
             else:
@@ -1646,10 +1666,7 @@ class BumpHunter2D(BumpHunterInterface):
         else:
             if not is_hist:
                 H = np.histogram2d(
-                    data[:, 0],
-                    data[:, 1],
-                    bins=self.bins,
-                    range=self.rang
+                    data[:, 0], data[:, 1], bins=self.bins, range=self.rang
                 )
                 H = [H[0], [H[1], H[2]]]
             else:
@@ -1657,22 +1674,24 @@ class BumpHunter2D(BumpHunterInterface):
 
         # Get bump min and max
         if multi_chan:
-            Bminx = np.array([
-                H[1][0][self.min_loc_ar[0][ch][0]]
-                for ch in range(len(data))
-            ])
-            Bmaxx = np.array([
-                H[1][0][self.min_loc_ar[0][ch][0] + self.min_width_ar[0][ch][0]]
-                for ch in range(len(data))
-            ])
-            Bminy = np.array([
-                H[1][1][self.min_loc_ar[0][ch][1]]
-                for ch in range(len(data))
-            ])
-            Bmaxy = np.array([
-                H[1][1][self.min_loc_ar[0][ch][1] + self.min_width_ar[0][ch][1]]
-                for ch in range(len(data))
-            ])
+            Bminx = np.array(
+                [H[1][0][self.min_loc_ar[0][ch][0]] for ch in range(len(data))]
+            )
+            Bmaxx = np.array(
+                [
+                    H[1][0][self.min_loc_ar[0][ch][0] + self.min_width_ar[0][ch][0]]
+                    for ch in range(len(data))
+                ]
+            )
+            Bminy = np.array(
+                [H[1][1][self.min_loc_ar[0][ch][1]] for ch in range(len(data))]
+            )
+            Bmaxy = np.array(
+                [
+                    H[1][1][self.min_loc_ar[0][ch][1] + self.min_width_ar[0][ch][1]]
+                    for ch in range(len(data))
+                ]
+            )
             Bminx = Bminx.max()
             Bmaxx = Bmaxx.min()
             Bminy = Bminy.max()
@@ -1802,7 +1821,7 @@ class BumpHunter2D(BumpHunterInterface):
         if show_Pval:
             plt.title(
                 f"BumpHunter statistics distribution      global p-value = {self.global_Pval:1.4f}",
-                size="xx-large"
+                size="xx-large",
             )
         else:
             plt.title("BumpHunter statistics distribution")
@@ -1925,7 +1944,7 @@ class BumpHunter2D(BumpHunterInterface):
         return self.plot_inject(*args, **kwargs)
 
     # Method to obtained a printable string containing all the results of the last BumpHunter scans
-    def bump_info(self, data, is_hist: bool=False):
+    def bump_info(self, data, is_hist: bool = False):
         """
         Method that return a formated string with all the results of the last performed scan.
 
@@ -1956,15 +1975,12 @@ class BumpHunter2D(BumpHunterInterface):
                         data[ch][:, 0],
                         data[ch][:, 1],
                         bins=self.bins[ch],
-                        range=self.rang
+                        range=self.rang,
                     )
                     bins.append([binx, biny])
             else:
                 _, binx, biny = np.histogram2d(
-                    data[:,0],
-                    data[:, 1],
-                    bins=self.bins,
-                    range=self.rang
+                    data[:, 0], data[:, 1], bins=self.bins, range=self.rang
                 )
                 bins = [binx, biny]
         else:
@@ -1973,22 +1989,24 @@ class BumpHunter2D(BumpHunterInterface):
         # Get the bin edges
         if multi_chan:
             # Get edges for all chanels
-            Bminx = np.array([
-                bins[ch][0][self.min_loc_ar[0][ch][0]]
-                for ch in range(len(data))
-            ])
-            Bmaxx = np.array([
-                bins[ch][0][self.min_loc_ar[0][ch][0] + self.min_width_ar[0][ch][0]]
-                for ch in range(len(data))
-            ])
-            Bminy = np.array([
-                bins[ch][1][self.min_loc_ar[0][ch][1]]
-                for ch in range(len(data))
-            ])
-            Bmaxy = np.array([
-                bins[ch][1][self.min_loc_ar[0][ch][1] + self.min_width_ar[0][ch][1]]
-                for ch in range(len(data))
-            ])
+            Bminx = np.array(
+                [bins[ch][0][self.min_loc_ar[0][ch][0]] for ch in range(len(data))]
+            )
+            Bmaxx = np.array(
+                [
+                    bins[ch][0][self.min_loc_ar[0][ch][0] + self.min_width_ar[0][ch][0]]
+                    for ch in range(len(data))
+                ]
+            )
+            Bminy = np.array(
+                [bins[ch][1][self.min_loc_ar[0][ch][1]] for ch in range(len(data))]
+            )
+            Bmaxy = np.array(
+                [
+                    bins[ch][1][self.min_loc_ar[0][ch][1] + self.min_width_ar[0][ch][1]]
+                    for ch in range(len(data))
+                ]
+            )
 
             # Take common overlap window
             Bminc = np.array([Bminx.max(), Bminy.max()])
@@ -1996,62 +2014,63 @@ class BumpHunter2D(BumpHunterInterface):
             Bmean = (Bminc + Bmaxc) / 2
             Bwidth = Bmaxc - Bminc
         else:
-            Bmin = np.array([
-                bins[0][self.min_loc_ar[0][0]],
-                bins[1][self.min_loc_ar[0][1]]
-            ])
-            Bmax = np.array([
-                bins[0][self.min_loc_ar[0][0] + self.min_width_ar[0][0]],
-                bins[1][self.min_loc_ar[0][1] + self.min_width_ar[0][1]]
-            ])
+            Bmin = np.array(
+                [bins[0][self.min_loc_ar[0][0]], bins[1][self.min_loc_ar[0][1]]]
+            )
+            Bmax = np.array(
+                [
+                    bins[0][self.min_loc_ar[0][0] + self.min_width_ar[0][0]],
+                    bins[1][self.min_loc_ar[0][1] + self.min_width_ar[0][1]],
+                ]
+            )
             Bmean = (Bmin + Bmax) / 2
             Bwidth = Bmax - Bmin
 
         # Initialise the string
-        bstr = ''
+        bstr = ""
 
         # Append local results to the string
         if multi_chan:
             # Append the bump edges of every channels (x and y separatetly)
-            bstr += 'Bump edges (per channel):\n'
+            bstr += "Bump edges (per channel):\n"
             for ch in range(len(self.min_Pval_ar[0])):
-                bstr += f'    chan {ch+1} -> x=[{Bminx[ch]:.3g}, {Bmaxx[ch]:.3g}] y=[{Bminy[ch]:.3g}, {Bmaxy[ch]:.3g}]'
-                bstr += f'  (loc={self.min_loc_ar[0][ch]}, width={self.min_width_ar[0][ch]})\n'
+                bstr += f"    chan {ch + 1} -> x=[{Bminx[ch]:.3g}, {Bmaxx[ch]:.3g}] y=[{Bminy[ch]:.3g}, {Bmaxy[ch]:.3g}]"
+                bstr += f"  (loc={self.min_loc_ar[0][ch]}, width={self.min_width_ar[0][ch]})\n"
 
             # Append the combined bump edges, mean and width (x and y separately)
-            bstr += f'Combined bump edges : x=[{Bminc[0]:.3g}, {Bmaxc[0]:.3g}] y=[{Bminc[1]:.3g}, {Bmaxc[1]:.3g}]\n'
-            bstr += f'Combined bump mean | width : [{Bmean[0]:.3g}, {Bmean[1]:.3g}]'
-            bstr += f' | [{Bwidth[0]:.3g}, {Bwidth[1]:.3g}]\n'
+            bstr += f"Combined bump edges : x=[{Bminc[0]:.3g}, {Bmaxc[0]:.3g}] y=[{Bminc[1]:.3g}, {Bmaxc[1]:.3g}]\n"
+            bstr += f"Combined bump mean | width : [{Bmean[0]:.3g}, {Bmean[1]:.3g}]"
+            bstr += f" | [{Bwidth[0]:.3g}, {Bwidth[1]:.3g}]\n"
 
             # Append evavuated number of signal event (per channel and total)
-            bstr += 'Evaluated number f signal events (per channel):\n'
+            bstr += "Evaluated number f signal events (per channel):\n"
             for ch in range(len(self.min_Pval_ar[0])):
-                bstr += f'    chan {ch+1} -> {self.signal_eval[ch]:.3g\n}'
-            bstr += f'    Total -> {self.signal_eval.sum():.3g}\n'
+                bstr += f"    chan {ch + 1} -> {self.signal_eval[ch]:.3g\n}"
+            bstr += f"    Total -> {self.signal_eval.sum():.3g}\n"
 
             # Append local information
-            bstr += 'Local p-value (per channel):\n'
+            bstr += "Local p-value (per channel):\n"
             for ch in range(len(self.min_Pval_ar[0])):
-                bstr += f'    chan {ch+1} -> {self.min_Pval_ar[0][ch]:.5g}\n'
-            bstr += f'Local p-value | test statistic (combined) : {self.min_Pval_ar[0].prod():.5g}'
-            bstr += f' | {self.t_ar[0]:.5g}\n'
-            bstr += f'Local significance (combined) : {norm.ppf(1 - self.min_Pval_ar[0].prod()):.5g}\n'
+                bstr += f"    chan {ch + 1} -> {self.min_Pval_ar[0][ch]:.5g}\n"
+            bstr += f"Local p-value | test statistic (combined) : {self.min_Pval_ar[0].prod():.5g}"
+            bstr += f" | {self.t_ar[0]:.5g}\n"
+            bstr += f"Local significance (combined) : {norm.ppf(1 - self.min_Pval_ar[0].prod()):.5g}\n"
         else:
             # Append results for only one channel (no 'combined', x and y separately)
-            bstr += f'Bump edges : x=[{Bmin[0]:.3g}, {Bmax[0]:.3g}] y=[{Bmin[1]:.3g}, {Bmax[1]:.3g}]'
-            bstr += f'  (loc={self.min_loc_ar[0]}, width={self.min_width_ar[0]})\n'
-            bstr += f'Bump mean | width : [{Bmean[0]:.3g}, {Bmean[1]:.3g}] | [{Bwidth[0]:.3g}, {Bwidth[1]:.3g}]\n'
-            bstr += f'Evaluated number of signal events : {self.signal_eval:.3g}\n'
-            bstr += f'Local p-value | test statistic : {self.min_Pval_ar[0]:.5g}'
-            bstr += f' | {self.t_ar[0]:.5g}\n'
-            bstr += f'Local significance : {norm.ppf(1 - self.min_Pval_ar[0]):.5g}\n'
+            bstr += f"Bump edges : x=[{Bmin[0]:.3g}, {Bmax[0]:.3g}] y=[{Bmin[1]:.3g}, {Bmax[1]:.3g}]"
+            bstr += f"  (loc={self.min_loc_ar[0]}, width={self.min_width_ar[0]})\n"
+            bstr += f"Bump mean | width : [{Bmean[0]:.3g}, {Bmean[1]:.3g}] | [{Bwidth[0]:.3g}, {Bwidth[1]:.3g}]\n"
+            bstr += f"Evaluated number of signal events : {self.signal_eval:.3g}\n"
+            bstr += f"Local p-value | test statistic : {self.min_Pval_ar[0]:.5g}"
+            bstr += f" | {self.t_ar[0]:.5g}\n"
+            bstr += f"Local significance : {norm.ppf(1 - self.min_Pval_ar[0]):.5g}\n"
 
         # Append global results to the string
-        bstr += f'Global p-value : {self.global_Pval:.5g}\n'
+        bstr += f"Global p-value : {self.global_Pval:.5g}\n"
         if self.global_Pval == 0:
-            bstr += f'Global significance : >{self.significance:.3g}  (lower limit)'
+            bstr += f"Global significance : >{self.significance:.3g}  (lower limit)"
         else:
-            bstr += f'Global significance : {self.significance:.3g}'
+            bstr += f"Global significance : {self.significance:.3g}"
 
         return bstr
 
@@ -2067,7 +2086,7 @@ class BumpHunter2D(BumpHunterInterface):
         print("BUMP WINDOW")
         print(f"   loc = {self.min_loc_ar[0]}")
         print(f"   width = {self.min_width_ar[0]}")
-        
+
         # Check if there ara multiple channels
         if not isinstance(self.min_Pval_ar[0], np.ndarray):
             # Print stuff for 1 channel
@@ -2076,25 +2095,18 @@ class BumpHunter2D(BumpHunterInterface):
             print(f"   local significance = {norm.ppf(1 - self.min_Pval_ar[0]):.5f}")
         else:
             # Print stuf for multiple channels
-            print(
-                "   local p-value (per channel) = [",
-                end=''
-            )
+            print("   local p-value (per channel) = [", end="")
             [
-                print(f"{self.min_Pval_ar[0][ch]:.5g}  ",end='')
+                print(f"{self.min_Pval_ar[0][ch]:.5g}  ", end="")
                 for ch in range(len(self.min_Pval_ar[0]))
             ]
             print("]")
-            print(
-                f"   local p-value (combined) = {self.min_Pval_ar[0].prod():.5g}"
-            )
-            print(
-                f"   -ln(loc p-value) (combined) = {self.t_ar[0]:.5f}"
-            )
+            print(f"   local p-value (combined) = {self.min_Pval_ar[0].prod():.5g}")
+            print(f"   -ln(loc p-value) (combined) = {self.t_ar[0]:.5f}")
             print(
                 f"   local significance (combined) = {norm.ppf(1 - self.min_Pval_ar[0].prod()):.5f}"
             )
-            
+
         print("")
 
         return
@@ -2140,52 +2152,51 @@ class BumpHunter2D(BumpHunterInterface):
                         data[ch][:, 0],
                         data[ch][:, 1],
                         bins=self.bins[ch],
-                        range=self.rang
+                        range=self.rang,
                     )
                     bins.append([binx, biny])
             else:
                 _, binx, biny = np.histogram2d(
-                    data[:,0],
-                    data[:, 1],
-                    bins=self.bins,
-                    range=self.rang
+                    data[:, 0], data[:, 1], bins=self.bins, range=self.rang
                 )
                 bins = [binx, biny]
         else:
             bins = self.bins
 
-
         # Compute real bin edges
         if multi_chan:
-            Bminx = np.array([
-                bins[ch][0][self.min_loc_ar[0][ch][0]]
-                for ch in range(len(data))
-            ])
-            Bmaxx = np.array([
-                bins[ch][0][self.min_loc_ar[0][ch][0] + self.min_width_ar[0][ch][0]]
-                for ch in range(len(data))
-            ])
-            Bminy = np.array([
-                bins[ch][1][self.min_loc_ar[0][ch][1]]
-                for ch in range(len(data))
-            ])
-            Bmaxy = np.array([
-                bins[ch][1][self.min_loc_ar[0][ch][1] + self.min_width_ar[0][ch][1]]
-                for ch in range(len(data))
-            ])
-            
+            Bminx = np.array(
+                [bins[ch][0][self.min_loc_ar[0][ch][0]] for ch in range(len(data))]
+            )
+            Bmaxx = np.array(
+                [
+                    bins[ch][0][self.min_loc_ar[0][ch][0] + self.min_width_ar[0][ch][0]]
+                    for ch in range(len(data))
+                ]
+            )
+            Bminy = np.array(
+                [bins[ch][1][self.min_loc_ar[0][ch][1]] for ch in range(len(data))]
+            )
+            Bmaxy = np.array(
+                [
+                    bins[ch][1][self.min_loc_ar[0][ch][1] + self.min_width_ar[0][ch][1]]
+                    for ch in range(len(data))
+                ]
+            )
+
             # Take common overlap window
             Bmin = np.array([Bminx.max(), Bminy.max()])
             Bmax = np.array([Bmaxx.min(), Bmaxy.min()])
         else:
-            Bmin = np.array([
-                bins[0][self.min_loc_ar[0][0]],
-                bins[1][self.min_loc_ar[0][1]]
-            ])
-            Bmax = np.array([
-                bins[0][self.min_loc_ar[0][0] + self.min_width_ar[0][0]],
-                bins[1][self.min_loc_ar[0][1] + self.min_width_ar[0][1]]
-            ])
+            Bmin = np.array(
+                [bins[0][self.min_loc_ar[0][0]], bins[1][self.min_loc_ar[0][1]]]
+            )
+            Bmax = np.array(
+                [
+                    bins[0][self.min_loc_ar[0][0] + self.min_width_ar[0][0]],
+                    bins[1][self.min_loc_ar[0][1] + self.min_width_ar[0][1]],
+                ]
+            )
         Bmean = (Bmin + Bmax) / 2
         Bwidth = Bmax - Bmin
 

--- a/test/test_BumpHunter2D.py
+++ b/test/test_BumpHunter2D.py
@@ -6,6 +6,7 @@ import pyBumpHunter as BH
 import pytest
 import numpy as np
 
+
 # Function to generate a dataset with numpy
 def make_datasets(seed):
     np.random.seed(seed)
@@ -27,22 +28,27 @@ def make_datasets(seed):
     # Return the dataset
     return data, bkg
 
+
 @pytest.fixture
 def data_sig_bkg1():
     return make_datasets(seed=42)
 
+
 @pytest.fixture
 def bhunter():
-    return BH.BumpHunter2D(rang=[[0, 25], [0, 25]],
-                           width_min=[2, 2],
-                           width_max=[3, 3],
-                           width_step=[1, 1],
-                           scan_step=[1, 1],
-                           bins=[20, 20],
-                           npe=8000,
-                           nworker=1,
-                           seed=666,
-                           use_sideband=True)
+    return BH.BumpHunter2D(
+        rang=[[0, 25], [0, 25]],
+        width_min=[2, 2],
+        width_max=[3, 3],
+        width_step=[1, 1],
+        scan_step=[1, 1],
+        bins=[20, 20],
+        npe=8000,
+        nworker=1,
+        seed=666,
+        use_sideband=True,
+    )
+
 
 # Test if the bump_scan method runs
 def test_scan_run(data_sig_bkg1, bhunter):
@@ -59,11 +65,11 @@ def test_scan_run(data_sig_bkg1, bhunter):
     assert bhunter.min_width_ar[0] == [3, 3]
 
     # Test if the local p-value is correct w.r.t. the expected value (up to 5 digit)
-    assert f"{bhunter.min_Pval_ar[0]:.5g}" == '3.6572e-07'
+    assert f"{bhunter.min_Pval_ar[0]:.5g}" == "3.6572e-07"
 
     # Test if the global p-value is correct w.r.t. the expected value (up to 5 digit)
     assert f"{bhunter.global_Pval:.5f}" == "0.00063"
-    
+
     # Test if the number of tested intervals is correct w.r.t. the expected value
     N = 0
     for r in bhunter.res_ar:
@@ -74,7 +80,7 @@ def test_scan_run(data_sig_bkg1, bhunter):
     assert int(bhunter.signal_eval) == 277
 
 
-''' 2D signal injection is not implemented yet
+""" 2D signal injection is not implemented yet
 # Test if the SignalInject method runs
 def test_inject_run():
     BHtest.sigma_limit = 5
@@ -91,6 +97,4 @@ def test_signal_str():
 # Test if the number of injected event is correct w.r.t. the expected value
 def test_number_inject():
     assert int(BHtest.signal_min) == 300
-'''
-
-
+"""


### PR DESCRIPTION
This PR implements `.pre-commit-config.yaml` using `scikit-hep/hist` and `Scikit-HEP` guidelines as the architectural standard for the roadmap mentioned in #27 (Phase 1).

**Changes:**
- Modernized `.pre-commit-config.yaml`.
- Formatted the codebase using `ruff-format` and `ruff-check`.
- Patched two minor linter warnings in `bumphunter_2dim.py`.

This PR is strictly limited to formatting and syntax. No algorithm logic was altered. 

Some tools such as `blacken-docs` and `mypy` were left out for now as they do not seem to currently apply to `pyBumpHunter`'s directory structure or documentation layout.  
@eduardo-rodrigues @henryiii Let me know your thoughts on it. 