### PR TITLE
ci: Modernize GitHub Actions and expand Python matrix (Phase 2.1)

### DIFF
--- a/.github/workflows/automated_testing.yml
+++ b/.github/workflows/automated_testing.yml
@@ -5,24 +5,15 @@ on:
   pull_request:
     branches:
       - master
+      - main
 
 jobs:
-  pre-commit:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
-      with:
-        python-version: "3.12"
-    - uses: pre-commit/action@v3.0.1
-
   build:
-    needs: pre-commit
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/automated_testing.yml
+++ b/.github/workflows/automated_testing.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - master
-      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/automated_testing.yml
+++ b/.github/workflows/automated_testing.yml
@@ -2,25 +2,36 @@ name: automated_testing
 
 on:
   push:
-
   pull_request:
     branches:
       - master
 
 jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+    - uses: pre-commit/action@v3.0.1
+
   build:
+    needs: pre-commit
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        python-version: [3.8,3.9,'3.10']
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
 
     - name: Setup python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
This PR updates the core CI pipeline to ensure tests run securely and on modern environments based on the Scikit-HEP guidelines and roadmap for modernization as discussed in #27 phase 2. 

**Changes:**
- Upgraded `actions/checkout` to v4 and `actions/setup-python` to v5.
- Expanded the `pytest` matrix to test against Python 3.8 through 3.14. 
- Added `fail-fast: false` and `allow-prereleases: true` to safely support testing against experimental Python 3.14 builds without blocking standard tests.
- Added a `pre-commit` job that runs *before* the test matrix to enforce code quality automatically on future PRs, reducing CI compute resources.

This PR has no effect or dependence on #30 and vice versa. 

@eduardo-rodrigues @henryiii @lovaslin let me know your thoughts/ any suggestions on this. 