### PR TITLE
ci: Integrate codecov for test coverage tracking (Phase 2.3)

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,11 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true

--- a/.github/workflows/automated_testing.yml
+++ b/.github/workflows/automated_testing.yml
@@ -32,7 +32,13 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -e .[test]
+        pip install pytest-cov
 
     - name: Run test
       run: |
-        pytest
+        pytest --cov=pyBumpHunter --cov-report=xml
+
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@v6
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Last part of #27 (Phase 2).

This PR completes the Phase 2 CI/CD pipeline revamp, with automated test coverage reporting via Codecov, in alignment with Scientific Python development guidelines.

**Changes:**
- Updated the `pytest` step to generate an XML coverage report (`pytest-cov`).
- Added the `codecov/codecov-action@v6` upload step.
- Added `.codecov.yml` and set the status checks to `informational: true` so low legacy coverage does not block or fail future PRs, but still provides baseline visibility to reviewers.

@eduardo-rodrigues @henryiii @lovaslin let me know your thoughts on it. 