### PR TITLE
fix: resolve numpy array comparisons in 2D module (Phase 4.1)

### DIFF
--- a/pyBumpHunter/bumphunter_2dim.py
+++ b/pyBumpHunter/bumphunter_2dim.py
@@ -1203,8 +1203,8 @@ class BumpHunter2D(BumpHunterInterface):
             else:
                 if len(self.min_Pval_ar) == 0:
                     self.min_Pval_ar = np.empty(1)
-                    self.min_loc_ar = np.empty(1, dtype=int)
-                    self.min_width_ar = np.empty(1, dtype=int)
+                    self.min_loc_ar = np.empty(1, dtype=object)
+                    self.min_width_ar = np.empty(1, dtype=object)
                     self.t_ar = np.empty(1)
         else:
             if do_pseudo:
@@ -1215,8 +1215,8 @@ class BumpHunter2D(BumpHunterInterface):
             else:
                 if len(self.min_Pval_ar) == 0:
                     self.min_Pval_ar = np.empty(1)
-                    self.min_loc_ar = np.empty(1, dtype=int)
-                    self.min_width_ar = np.empty(1, dtype=int)
+                    self.min_loc_ar = np.empty(1, dtype=object)
+                    self.min_width_ar = np.empty(1, dtype=object)
                     self.t_ar = np.empty(1)
         self.res_ar = []
 

--- a/pyBumpHunter/bumphunter_2dim.py
+++ b/pyBumpHunter/bumphunter_2dim.py
@@ -1201,7 +1201,7 @@ class BumpHunter2D(BumpHunterInterface):
                 self.min_width_ar = np.empty(self.npe + 1, dtype=object)
                 self.t_ar = np.empty(self.npe + 1)
             else:
-                if self.min_Pval_ar == []:
+                if len(self.min_Pval_ar) == 0:
                     self.min_Pval_ar = np.empty(1)
                     self.min_loc_ar = np.empty(1, dtype=int)
                     self.min_width_ar = np.empty(1, dtype=int)
@@ -1213,7 +1213,7 @@ class BumpHunter2D(BumpHunterInterface):
                 self.min_width_ar = np.empty(self.npe + 1, dtype=object)
                 self.t_ar = np.empty(self.npe + 1)
             else:
-                if self.min_Pval_ar == []:
+                if len(self.min_Pval_ar) == 0:
                     self.min_Pval_ar = np.empty(1)
                     self.min_loc_ar = np.empty(1, dtype=int)
                     self.min_width_ar = np.empty(1, dtype=int)
@@ -1958,7 +1958,11 @@ class BumpHunter2D(BumpHunterInterface):
         """
 
         # Chek if we have multi-channel
-        if self.res_ar != [] and self.res_ar.ndim == 2:
+        if (
+            isinstance(self.res_ar, np.ndarray)
+            and self.res_ar.size > 0
+            and self.res_ar.ndim == 2
+        ):
             # We have multiple channels
             multi_chan = True
         else:
@@ -2135,7 +2139,11 @@ class BumpHunter2D(BumpHunterInterface):
         """
 
         # Chek if we have multi-channel
-        if self.res_ar != [] and self.res_ar.ndim == 2:
+        if (
+            isinstance(self.res_ar, np.ndarray)
+            and self.res_ar.size > 0
+            and self.res_ar.ndim == 2
+        ):
             # We have multiple channels
             multi_chan = True
         else:

--- a/test/test_BumpHunter2D.py
+++ b/test/test_BumpHunter2D.py
@@ -98,3 +98,19 @@ def test_signal_str():
 def test_number_inject():
     assert int(BHtest.signal_min) == 300
 """
+
+
+# Test if bump_info runs without crashing (verifies the numpy deprecation fix)
+def test_bump_info(data_sig_bkg1, bhunter):
+    data, bkg = data_sig_bkg1
+    bhunter.bump_scan(data, bkg)
+    info_str = bhunter.bump_info(data)
+    assert isinstance(info_str, str)
+    assert len(info_str) > 0
+
+
+# Test scan without pseudo experiments (verifies the TypeError fix)
+def test_scan_no_pseudo(data_sig_bkg1, bhunter):
+    data, bkg = data_sig_bkg1
+    bhunter.bump_scan(data, bkg, do_pseudo=False)
+    assert len(bhunter.min_loc_ar) > 0


### PR DESCRIPTION
Part of #27 (Phase 4.1). 

This PR resolves the `ValueError: operands could not be broadcast together` crashes in the 2D module, based on 1D fixes  observed in PR #26.

**Changes:**
- Replaced ambiguous `== []` checks with safe `len(x) == 0` checks for `min_Pval_ar`.
- Replaced `!= []` checks with type-safe `isinstance(x, np.ndarray) and x.size > 0` checks for `res_ar`.

Verified locally, running `example2D.py` now completes statistical reporting without crashing, and `pytest` confirms no mathematical regressions.
@eduardo-rodrigues @henryiii @lovaslin let me know for any suggestions. 