### PR TITLE
fix: surface scan worker errors and fix array truthiness checks

### DIFF
--- a/pyBumpHunter/bumphunter_1dim.py
+++ b/pyBumpHunter/bumphunter_1dim.py
@@ -1079,7 +1079,7 @@ class BumpHunter1D:
                 self.min_width_ar = np.empty(self.npe + 1, dtype=object)
                 self.t_ar = np.empty(self.npe + 1)
             else:
-                if self.min_Pval_ar == []:
+                if len(self.min_Pval_ar) == 0:
                     self.min_Pval_ar = np.empty(1)
                     self.min_loc_ar = np.empty(1, dtype=int)
                     self.min_width_ar = np.empty(1, dtype=int)
@@ -1091,7 +1091,7 @@ class BumpHunter1D:
                 self.min_width_ar = np.empty(self.npe + 1, dtype=int)
                 self.t_ar = np.empty(self.npe + 1)
             else:
-                if self.min_Pval_ar == []:
+                if len(self.min_Pval_ar) == 0:
                     self.min_Pval_ar = np.empty(1)
                     self.min_loc_ar = np.empty(1, dtype=int)
                     self.min_width_ar = np.empty(1, dtype=int)
@@ -1108,45 +1108,48 @@ class BumpHunter1D:
         if do_pseudo:
             if self.nworker > 1:
                 with thd.ThreadPoolExecutor(max_workers=self.nworker) as exe:
+                    futures = []
                     for th in range(self.npe + 1):
                         if multi_chan:
                             if th == 0:
-                                exe.submit(
+                                futures.append(exe.submit(
                                     self._scan_hist_multi,
                                     data_hist,
                                     bkg_hist,
                                     w_ar,
                                     th,
-                                )
+                                ))
                             else:
                                 pseudo = [
                                     pseudo_hist[ch][:, th - 1]
                                     for ch in range(len(data))
                                 ]
-                                exe.submit(
+                                futures.append(exe.submit(
                                     self._scan_hist_multi,
                                     pseudo,
                                     bkg_hist,
                                     w_ar,
                                     th,
-                                )
+                                ))
                         else:
                             if th == 0:
-                                exe.submit(
+                                futures.append(exe.submit(
                                     self._scan_hist,
                                     data_hist,
                                     bkg_hist,
                                     w_ar,
                                     th,
-                                )
+                                ))
                             else:
-                                exe.submit(
+                                futures.append(exe.submit(
                                     self._scan_hist,
                                     pseudo_hist[:, th - 1],
                                     bkg_hist,
                                     w_ar,
                                     th,
-                                )
+                                ))
+                    for f in futures:
+                        f.result()
             else:
                 for i in range(self.npe + 1):
                     if multi_chan:
@@ -1295,8 +1298,12 @@ class BumpHunter1D:
         print("BACKGROUND ONLY SCAN")
         if self.nworker > 1:
             with thd.ThreadPoolExecutor(max_workers=self.nworker) as exe:
-                for th in range(self.npe):
+                futures = [
                     exe.submit(self._scan_hist, pseudo_bkg[:, th], bkg_hist, w_ar, th)
+                    for th in range(self.npe)
+                ]
+                for f in futures:
+                    f.result()
         else:
             for th in range(self.npe):
                 self._scan_hist(pseudo_bkg[:, th], bkg_hist, w_ar, th)
@@ -1387,10 +1394,14 @@ class BumpHunter1D:
             print("BACKGROUND+SIGNAL SCAN")
             if self.nworker > 1:
                 with thd.ThreadPoolExecutor(max_workers=self.nworker) as exe:
-                    for th in range(self.npe_inject):
+                    futures = [
                         exe.submit(
                             self._scan_hist, pseudo_data[:, th], bkg_hist, w_ar, th
                         )
+                        for th in range(self.npe_inject)
+                    ]
+                    for f in futures:
+                        f.result()
             else:
                 for th in range(self.npe_inject):
                     self._scan_hist(pseudo_data[:, th], bkg_hist, w_ar, th)

--- a/pyBumpHunter/bumphunter_2dim.py
+++ b/pyBumpHunter/bumphunter_2dim.py
@@ -1232,41 +1232,44 @@ class BumpHunter2D(BumpHunterInterface):
         if do_pseudo:
             if self.nworker > 1:
                 with thd.ThreadPoolExecutor(max_workers=self.nworker) as exe:
+                    futures = []
                     for th in range(self.npe + 1):
                         if multi_chan:
                             if th == 0:
-                                exe.submit(
+                                futures.append(exe.submit(
                                     self._scan_hist_multi,
                                     data_hist,
                                     bkg_hist,
                                     w_ar,
                                     th,
-                                )
+                                ))
                             else:
                                 pseudo = [
                                     pseudo_hist[ch][:, :, th - 1]
                                     for ch in range(len(data))
                                 ]
-                                exe.submit(
+                                futures.append(exe.submit(
                                     self._scan_hist_multi,
                                     pseudo,
                                     bkg_hist,
                                     w_ar,
                                     th,
-                                )
+                                ))
                         else:
                             if th == 0:
-                                exe.submit(
+                                futures.append(exe.submit(
                                     self._scan_hist, data_hist, bkg_hist, w_ar, th
-                                )
+                                ))
                             else:
-                                exe.submit(
+                                futures.append(exe.submit(
                                     self._scan_hist,
                                     pseudo_hist[:, :, th - 1],
                                     bkg_hist,
                                     w_ar,
                                     th,
-                                )
+                                ))
+                    for f in futures:
+                        f.result()
             else:
                 for i in range(self.npe + 1):
                     if multi_chan:
@@ -1415,8 +1418,12 @@ class BumpHunter2D(BumpHunterInterface):
         print("BACKGROUND ONLY SCAN")
         if self.nworker > 1:
             with thd.ThreadPoolExecutor(max_workers=self.nworker) as exe:
-                for th in range(Nbkg):
+                futures = [
                     exe.submit(self._scan_hist, pseudo_bkg[:, th], bkg_hist, w_ar, th)
+                    for th in range(Nbkg)
+                ]
+                for f in futures:
+                    f.result()
         else:
             for th in range(Nbkg):
                 self._scan_hist(pseudo_bkg[:, th], bkg_hist, w_ar, th)
@@ -1505,10 +1512,14 @@ class BumpHunter2D(BumpHunterInterface):
             print("BACKGROUND+SIGNAL SCAN")
             if self.nworker > 1:
                 with thd.ThreadPoolExecutor(max_workers=self.nworker) as exe:
-                    for th in range(self.npe):
+                    futures = [
                         exe.submit(
                             self._scan_hist, pseudo_data[:, th], bkg_hist, w_ar, th
                         )
+                        for th in range(self.npe)
+                    ]
+                    for f in futures:
+                        f.result()
             else:
                 for th in range(self.npe):
                     self._scan_hist(pseudo_data[:, th], bkg_hist, w_ar, th)


### PR DESCRIPTION
:robot: _AI text below_ :robot:

This PR improves robustness of the parallel scan paths in both modules.

- **Fix 1 (both modules):** All `ThreadPoolExecutor.submit()` calls in `bump_scan` and `signal_inject` now collect the returned futures and call `.result()` on each. Previously, exceptions raised inside worker threads were silently swallowed, leaving result arrays filled with uninitialized `np.empty(...)` garbage. Affected sites: 4 submit calls in `bumphunter_1dim.py bump_scan`, 2 in `bumphunter_1dim.py signal_inject`, 4 in `bumphunter_2dim.py bump_scan`, and 2 in `bumphunter_2dim.py signal_inject`.
- **Fix 2 (1D module only):** Replaced `if self.min_Pval_ar == []:` with `if len(self.min_Pval_ar) == 0:` in the two `do_pseudo=False` branches of `bumphunter_1dim.py bump_scan`. When the method is called a second time, `min_Pval_ar` is already a NumPy array, causing `ndarray == []` to raise an ambiguous truth-value error. The 2D module already used the correct `len(...)` form.

Refs #35