### PR TITLE
fix: resolve multi-channel plot bug and purge Python 3.8 docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The BumpHunter algorithm can also perform signal injection tests where more and 
 
 ### Dependencies
 
-Requires Python >= 3.8.
+Requires Python >= 3.9.
 
 BumpHunter depends on the following python libraries :
 

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python>=3.8
+  - python>=3.9
   - jupyter
   - numpy>=1.13.3
   - matplotlib

--- a/pyBumpHunter/bumphunter_1dim.py
+++ b/pyBumpHunter/bumphunter_1dim.py
@@ -1112,42 +1112,50 @@ class BumpHunter1D:
                     for th in range(self.npe + 1):
                         if multi_chan:
                             if th == 0:
-                                futures.append(exe.submit(
-                                    self._scan_hist_multi,
-                                    data_hist,
-                                    bkg_hist,
-                                    w_ar,
-                                    th,
-                                ))
+                                futures.append(
+                                    exe.submit(
+                                        self._scan_hist_multi,
+                                        data_hist,
+                                        bkg_hist,
+                                        w_ar,
+                                        th,
+                                    )
+                                )
                             else:
                                 pseudo = [
                                     pseudo_hist[ch][:, th - 1]
                                     for ch in range(len(data))
                                 ]
-                                futures.append(exe.submit(
-                                    self._scan_hist_multi,
-                                    pseudo,
-                                    bkg_hist,
-                                    w_ar,
-                                    th,
-                                ))
+                                futures.append(
+                                    exe.submit(
+                                        self._scan_hist_multi,
+                                        pseudo,
+                                        bkg_hist,
+                                        w_ar,
+                                        th,
+                                    )
+                                )
                         else:
                             if th == 0:
-                                futures.append(exe.submit(
-                                    self._scan_hist,
-                                    data_hist,
-                                    bkg_hist,
-                                    w_ar,
-                                    th,
-                                ))
+                                futures.append(
+                                    exe.submit(
+                                        self._scan_hist,
+                                        data_hist,
+                                        bkg_hist,
+                                        w_ar,
+                                        th,
+                                    )
+                                )
                             else:
-                                futures.append(exe.submit(
-                                    self._scan_hist,
-                                    pseudo_hist[:, th - 1],
-                                    bkg_hist,
-                                    w_ar,
-                                    th,
-                                ))
+                                futures.append(
+                                    exe.submit(
+                                        self._scan_hist,
+                                        pseudo_hist[:, th - 1],
+                                        bkg_hist,
+                                        w_ar,
+                                        th,
+                                    )
+                                )
                     for f in futures:
                         f.result()
             else:
@@ -1691,7 +1699,7 @@ class BumpHunter1D:
 
                 H = [H[0], H[1]]
             else:
-                H = np.histogram(data[chan], bins=self.bins, range=self.rang)
+                H = np.histogram(data[chan], bins=self.bins[chan], range=self.rang)
         else:
             if not is_hist:
                 H = np.histogram(data, bins=self.bins, range=self.rang)


### PR DESCRIPTION
Part of #27 (Phase 4.2). Also Resolves #19.

This PR resolves the multi-channel plotting crash and cleans up the remaining Python 3.8 references to match our Phase 3 metadata updates.

**Changes:**
- **Issue #19:** Corrected the bin array indexing in `plot_bump` (`self.bins[chan]`) when `multi_chan` and `is_hist` are both True.
- **Python 3.8 Cleanup:** Updated `README.md` and `environment.yml` to explicitly require `Python >= 3.9` as requested.

Verified locally. All respective tests pass.
@eduardo-rodrigues @henryiii @lovaslin let me know your thoughts on it. 