### PR TITLE
ci: migrate to PyPI Trusted Publishing

### DIFF
--- a/.github/workflows/automated_build.yml
+++ b/.github/workflows/automated_build.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - master
-      - main
   release:
     types:
     - published
@@ -26,11 +25,18 @@ jobs:
     - name: Check metadata
       run: pipx run twine check dist/*
 
-
   publish:
     needs: [dist]
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'
+
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pyBumpHunter
+
+    # This permission block is MANDATORY for OIDC Trusted Publishing
+    permissions:
+      id-token: write
 
     steps:
     - uses: actions/download-artifact@v8.0.1
@@ -39,5 +45,3 @@ jobs:
         path: dist
 
     - uses: pypa/gh-action-pypi-publish@v1.14.0
-      with:
-        password: ${{secrets.PYTOKEN}}


### PR DESCRIPTION
Part of #27 (Phase 4.3).

The final PR based on the current modernization roadmap. It upgrades the deployment workflow to use **PyPI Trusted Publishing**, deprecating the legacy token/password methodology in accordance with modern PyPI and Scientific Python security standards.

**Changes:**
- Removed the legacy `password: ${{secrets.PYTOKEN}}` authentication.
- Added the mandatory `permissions: id-token: write` block to the publish job to allow GitHub to generate temp tokens.
- Removed unused `main` branch trigger for consistency with the rest of the repository.

@eduardo-rodrigues @henryiii @lovaslin .