### PR TITLE
Revert "ci: migrate to PyPI Trusted Publishing"

### DIFF
--- a/.github/workflows/automated_build.yml
+++ b/.github/workflows/automated_build.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - main
   release:
     types:
     - published
@@ -25,18 +26,11 @@ jobs:
     - name: Check metadata
       run: pipx run twine check dist/*
 
+
   publish:
     needs: [dist]
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'
-
-    environment:
-      name: pypi
-      url: https://pypi.org/p/pyBumpHunter
-
-    # This permission block is MANDATORY for OIDC Trusted Publishing
-    permissions:
-      id-token: write
 
     steps:
     - uses: actions/download-artifact@v8.0.1
@@ -45,3 +39,5 @@ jobs:
         path: dist
 
     - uses: pypa/gh-action-pypi-publish@v1.14.0
+      with:
+        password: ${{secrets.PYTOKEN}}


### PR DESCRIPTION
This reverts commit 66110650ff951076b70e8fcaedffc399bd7f937b.

FYI @KaranSinghDev and @henryiii, as per our recent exchanges, see https://github.com/scikit-hep/pyBumpHunter/issues/27 in particular.